### PR TITLE
Make compiler command verbose only.

### DIFF
--- a/compiler/stz-main.stanza
+++ b/compiler/stz-main.stanza
@@ -140,7 +140,8 @@ defn call-cc (asmfile:String, outfile:String, ccfiles:List<String>, ccflags:Fals
          escape(outfile),
          join(all-flags, " "),
          join(platform-flags, " ")]
-   println(cmd)
+   if has-flag?(parsed, "verbose") :
+      println(cmd)
 
    ;Call system compiler
    call-system(cmd)


### PR DESCRIPTION
This is to make my build tool look nicer while compiling.
